### PR TITLE
Make dark mode default

### DIFF
--- a/theme.config.js
+++ b/theme.config.js
@@ -56,12 +56,25 @@ export default {
         href="/favicon-16x16.png"
       />
       <meta name="msapplication-TileImage" content="/ms-icon-144x144.png" />
+      <script
+        lang="javascript"
+        dangerouslySetInnerHTML={{
+          __html: `if (!window.localStorage.getItem("theme_default")) {
+      window.localStorage.setItem("theme", "dark");
+      window.localStorage.setItem("theme_default", "dark");
+      document.documentElement.classList.add("dark");
+      document.documentElement.classList.remove("light");
+    }`,
+        }}
+      />
+      ;
     </>
   ),
   search: true,
   prevLinks: true,
   nextLinks: true,
   footer: true,
+
   footerEditLink: 'Edit this page on GitHub',
   footerText: (
     <>


### PR DESCRIPTION
There isn't a specific config flag for this, so I added a hack I found in their GitHub issues. This'll force darkmode on initial load and then folks can use the switcher to change.